### PR TITLE
agregar logger administrativo

### DIFF
--- a/src/main/java/com/backend/api/config/security/AuthenticationFilter.java
+++ b/src/main/java/com/backend/api/config/security/AuthenticationFilter.java
@@ -29,6 +29,8 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
   @SuppressWarnings("unused")
   private static final Logger logger = LogManager.getLogger(AuthenticationFilter.class);
 
+  private static final Logger loggerAdministrativo = LogManager.getLogger("LoggerAdministrativo");
+
   private AuthenticationManager authenticationManager;
 
   public AuthenticationFilter(AuthenticationManager authenticationManager) {
@@ -64,6 +66,8 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
     String token = Jwts.builder().setClaims(claims).signWith(key, SignatureAlgorithm.HS512)
         .setExpiration(exp).compact();
     res.addHeader("token", token);
+
+    loggerAdministrativo.info("[ingreso] usuario: " + ((User) auth.getPrincipal()).getUsername());
   }
 
   @Override

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,8 +10,17 @@
                 <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>
         </File>
+        <File name="LoggerAdministrativo" fileName="logs/eventosAdministrativos.log">
+        	<PatternLayout>
+        		<Pattern>%d %p %m%n</Pattern>
+        	</PatternLayout>
+        </File>
     </Appenders>
     <Loggers>
+    	<Logger name="LoggerAdministrativo" level="info" additivity="false">
+    		<AppenderRef ref="LoggerAdministrativo"/>
+    		<AppenderRef ref="LogToConsole"/>
+    	</Logger>
         <Logger name="com.backend.api" level="debug" additivity="false">
             <AppenderRef ref="LogToFile"/>
             <AppenderRef ref="LogToConsole"/>


### PR DESCRIPTION
Agregar logger para eventos administrativos como alta de usuarios, titulares, licencias etc.

Para obtener el logger se tiene que hacer:
`Logger loggerAdministrativo = LogManager.getLogger("LoggerAdministrativo");`
